### PR TITLE
Fix error with sklearn and np matrix

### DIFF
--- a/bow_rf/rf_main.py
+++ b/bow_rf/rf_main.py
@@ -22,8 +22,8 @@ y_test = test_data["target"]
 # apply BoW feature extraction
 vectorizer = TfidfVectorizer(norm='l2', max_features=1000)
 vectorizer = vectorizer.fit(X_train)
-X_train = vectorizer.transform(X_train).todense()
-X_test = vectorizer.transform(X_test).todense()
+X_train = np.asarray(vectorizer.transform(X_train).todense())
+X_test = np.asarray(vectorizer.transform(X_test).todense())
 # train the model
 rf = RandomForestClassifier(n_estimators=1000,
                             n_jobs=-1,


### PR DESCRIPTION
This will fix `bow_rf/rf_main.py` to run without error. Previously it crashed with the following error:
```
Traceback (most recent call last):
  File "./LineVul/bow_rf/rf_main.py", line 31, in <module>
    rf.fit(X_train, y_train)
  File "./LineVul/venv/lib64/python3.9/site-packages/sklearn/base.py", line 1151, in wrapper
    return fit_method(estimator, *args, **kwargs)
  File "./LineVul/venv/lib64/python3.9/site-packages/sklearn/ensemble/_forest.py", line 348, in fit
    X, y = self._validate_data(
  File "./LineVul/venv/lib64/python3.9/site-packages/sklearn/base.py", line 621, in _validate_data
    X, y = check_X_y(X, y, **check_params)
  File "./LineVul/venv/lib64/python3.9/site-packages/sklearn/utils/validation.py", line 1147, in check_X_y
    X = check_array(
  File "./LineVul/venv/lib64/python3.9/site-packages/sklearn/utils/validation.py", line 753, in check_array
    raise TypeError(
TypeError: np.matrix is not supported. Please convert to a numpy array with np.asarray. For more information see: https://numpy.org/doc/stable/reference/generated/numpy.matrix.html
```