### PR TITLE
Move dependencies to requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,16 +118,7 @@ cd LineVul
 
 Then, install the python dependencies via the following command:
 ```
-pip install gdown
-pip install transformers
-pip install captum
-pip install torch
-pip install numpy
-pip install tqdm
-pip install pickle
-pip install sklearn
-pip install pandas
-pip install tokenizers
+pip install -r requirements.txt
 ```
 
 ### About the Datasets

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+captum
+gdown
+numpy
+pandas
+scikit-learn
+tokenizers
+torch
+tqdm
+transformers


### PR DESCRIPTION
This moves all dependencies to a `requirements.txt`.
Additionally I have fixed some dependencies:
- `sklearn` -> `scikit-learn`
- `pickle` removed, as it is part of standard library and does not need to be installed